### PR TITLE
fixes infinite delay loop while debugging

### DIFF
--- a/atari2600dump.ino
+++ b/atari2600dump.ino
@@ -915,6 +915,7 @@ void waitForCartridge() {
 }
 
 void setup() {
+  DWTInitTimer();
   EEPROM8_init(128);
   hotplug = !EEPROM8_getValue(NO_HOTPLUG);
   stellaExt = !EEPROM8_getValue(NO_STELLAEXT);
@@ -993,6 +994,3 @@ void loop() {
   }
   MassStorage.loop();
 }
-
-
-


### PR DESCRIPTION
`DWTInitTimer()` was not called. Without this call, `CYCCNT` is not enabled and since it is used by the timing loop in `DWTDelayCycles`, this run endlessly (at least on my original STM32F103C8T6 while debugging with gdb and an stlink-v2).